### PR TITLE
Make the user configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Installs and configures the awscli command-line tool [(the new one, supporting a
 Configuring
 ===========
 
+##### `[:awscli][:compile_time]`
+
 You can control when the awscli tool will be installed during the chef run, either
 in the compile stage or in the converge stage.
 
@@ -19,13 +21,15 @@ Role then the awscli will pick up that role's credentials automatically from the
 metadata, so you may not need to configure the access keys. You might still want to configure the
 default region.
 
-The following attributes are optional and are not specified by default. If present these 
+##### `[:awscli][:config_profiles]`
+
+The following attributes are optional and are not specified by default. If present these
 will be used configure the awscli:
 
     [:awscli][:config_profiles]       - a hash of configuration profiles
     [:awscli][:config_profiles]<profile_key> - the name of the profile
     [:awscli][:config_profiles][<profile_key>]<option_name> = <option_value> - config options
-    
+
 For example, to configure the default profile, specify the following:
 
     'awscli': {
@@ -37,10 +41,17 @@ For example, to configure the default profile, specify the following:
         }
       }
     }
-    
+
 The keys and values inside the profile_key hash are placed directly into the awscli config file.
 Use this mechanism to specify additional configuration (such as output style) and additional profiles.
-    
+
+##### `[:awscli][:user]`
+
+The aws configuration is installed under the `root` user account by default.
+Override this if needed;
+For example, AWS ubuntu instances use the `ubuntu` user instead of `root`.
+When overriding the configuration will be saved under `/home/user`.
+
 Using
 =====
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default[:awscli][:compile_time] = false
+default[:awscli][:user] = "root"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'shlomo.swidler@orchestratus.com'
 license          'Apache 2.0'
 description      'Installs the AWS command line tools'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.0'
+version          '0.3.0'
 
 recipe "default", "Install AWS CLI tools"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,12 +20,17 @@ if node[:awscli][:compile_time]
 end
 
 if node[:awscli][:config_profiles]
-  config_file="/root/.aws/config"
+  user = node[:awscli][:user]
+  if user == "root"
+    config_file="/#{user}/.aws/config"
+  else
+    config_file="/home/#{user}/.aws/config"
+  end
 
   r = directory ::File.dirname(config_file) do
     recursive true
-    owner 'root'
-    group 'root'
+    owner user
+    group user
     mode 00700
     not_if { ::File.exists?(::File.dirname(config_file)) }
     if node[:awscli][:compile_time]
@@ -38,8 +43,8 @@ if node[:awscli][:config_profiles]
 
   r = template config_file do
     mode 00600
-    owner 'root'
-    group 'root'
+    owner user
+    group user
     source 'config.erb'
     not_if { ::File.exists?(config_file) }
     if node[:awscli][:compile_time]
@@ -49,5 +54,5 @@ if node[:awscli][:config_profiles]
   if node[:awscli][:compile_time]
     r.run_action(:create)
   end
-  
+
 end


### PR DESCRIPTION
- don't hard code 'root' user

AWS ubuntu instances use 'ubuntu' instead of 'root'
