### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,9 +5,12 @@ when 'debian', 'ubuntu'
   file = '/usr/local/bin/aws'
   cmd = 'apt-get install -y python-pip && pip install awscli'
   completion_file = '/etc/bash_completion.d/aws'
-when 'redhat', 'centos', 'fedora', 'amazon', 'scientific'
+when 'centos', 'fedora', 'amazon', 'scientific'
   file = '/usr/bin/aws'
   cmd = 'yum -y install python-pip && pip install awscli'
+when 'redhat'
+  file = '/usr/bin/aws'
+  cmd = 'easy_install pip && pip install awscli'
 end
 r = execute 'install awscli' do
   command cmd


### PR DESCRIPTION
The "python-pip" package doesn't not appear to exist on recent redhat versions, though I've only tested this on RH7, hence the fix for that OS only.
