### PR TITLE
Allow generating config files for multiple users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ For example, to configure the default profile, specify the following:
         'default' : {
           'region'               : 'us-east-1',
           'aws_access_key_id'    : 'SOMESECRET',
-          'aws_secret_access_key : 'ANOTHERSECRET'
+          'aws_secret_access_key : 'ANOTHERSECRET',
+          'user'                  : 'username',
         }
       }
     }
 
 The keys and values inside the profile_key hash are placed directly into the awscli config file.
 Use this mechanism to specify additional configuration (such as output style) and additional profiles.
+
+_Note:_ The 'user' key is an exception to the above rule. If present, the 'user' key in the profile hash specifies that that config should appear in the AWS CLI config file for that particular Unix user. This functionality is helpful if you need to configure the AWS CLI for multiple users.
 
 ##### `[:awscli][:user]`
 

--- a/templates/default/config.erb
+++ b/templates/default/config.erb
@@ -1,18 +1,17 @@
 # Configuration for the awscli tool
 
-<% default_profile = node[:awscli][:config_profiles]['default']
+<% default_profile = @config_profiles['default']
 unless default_profile.nil? %>
 [default]
 <%  default_profile.each do |key, value| %>
 <%= key %> = <%= value %>
-<%  end 
+<%  end
 end %>
 
-<% node[:awscli][:config_profiles].each do |profile, options| 
+<% @config_profiles.each do |profile, options|
 next if profile=='default' %>
 [profile <%= profile %>]
 <%   options.each do |key, value| %>
 <%= key %> = <%= value %>
 <%   end %>
-
 <% end %>


### PR DESCRIPTION
Currently it's not possible to use to cookbook to generate multiple config files (for different users.) This PR adds support for that feature while retaining backwards compatibility.